### PR TITLE
limit users api for non admin users

### DIFF
--- a/src/server/routes/configuration.js
+++ b/src/server/routes/configuration.js
@@ -1,11 +1,19 @@
 const express = require("express");
 const router = express.Router();
 const { requireUser } = require("../access-helpers");
-const { users, roles, tables, templates } = require("../db");
+const {
+  user: getUser,
+  users: getUsers,
+  roles,
+  tables,
+  templates
+} = require("../db");
 
-router.get("/", requireUser, function(req, res) {
-  const ps = [users(), roles(), tables(), templates()];
-  Promise.all(ps).then(([users, roles, tables, templates]) => {
+router.get("/", requireUser, async function(req, res) {
+  const user = await getUser(req.signedCookies.userId);
+  const users = user.role === "admin" ? await getUsers() : [user];
+  const ps = [roles(), tables(), templates()];
+  Promise.all(ps).then(([roles, tables, templates]) => {
     res.json({ configuration: { users, roles, tables, templates } });
   });
 });


### PR DESCRIPTION
Allows non admins to still use the /api/users, but it only includes the current user. Admins see the entire list