### PR TITLE
Add download template button

### DIFF
--- a/src/components/GrantsOfficeHome.vue
+++ b/src/components/GrantsOfficeHome.vue
@@ -10,6 +10,11 @@
               >Download Treasury Report</a
             >
           </div>
+          <div class="mt-2">
+            <a :href="downloadTemplateUrl()" class="btn btn-primary" download
+              >Download Template</a
+            >
+          </div>
         </div>
         <div class="mt-3 col-4" v-if="currentReportingPeriod">
           <h3>Current Reporting Period</h3>
@@ -99,6 +104,9 @@ export default {
     titleize,
     downloadUrl() {
       return `/api/exports`;
+    },
+    downloadTemplateUrl() {
+      return `/templates/empty-template.xlsx`;
     },
     documentCount(tableName) {
       const records = this.groups[tableName];

--- a/src/server/configure.js
+++ b/src/server/configure.js
@@ -27,6 +27,7 @@ module.exports = app => {
   app.use("/api/sessions", require("./routes/sessions"));
   app.use("/api/uploads", require("./routes/uploads"));
   app.use("/api/users", require("./routes/users"));
+  app.use("/templates", express.static(__dirname + "/data"));
   if (process.env.NODE_ENV != "development") {
     const staticMiddleware = express.static(publicPath, staticConf);
     app.use(staticMiddleware);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16976453/95541935-a87cf900-09c2-11eb-9a9d-accd9dfbfe29.png)

Adds a template download button for admins

Open questions
- Should this functionality also be available for non-admins? Where should the button go?
- Are we comfortable using the `data` folder for serving static assets (i.e we should not be putting anything sensitive in this folder)