### PR TITLE
stop sending welcome email because of sendgrid link problems

### DIFF
--- a/src/server/routes/users.js
+++ b/src/server/routes/users.js
@@ -2,7 +2,6 @@ const express = require("express");
 const router = express.Router();
 const { requireAdminUser } = require("../access-helpers");
 const { createUser } = require("../db");
-const { sendWelcomeEmail } = require("../lib/email");
 
 router.post("/", requireAdminUser, function(req, res, next) {
   console.log("POST /users");
@@ -19,7 +18,6 @@ router.post("/", requireAdminUser, function(req, res, next) {
   };
   createUser(user)
     .then(result => res.json({ user: result }))
-    .then(() => sendWelcomeEmail(user.email, req.headers.origin))
     .catch(e => {
       if (e.message.match(/violates unique constraint/)) {
         res.status(400).send("User with that email already exists");


### PR DESCRIPTION
Sendgrid is apparently rewriting the link in the welcome email, and it goes to a "Not found" error page.
