### PR TITLE
Candidate fix for duplicate sub-recipient records - issue #43

### DIFF
--- a/src/server/routes/documents.js
+++ b/src/server/routes/documents.js
@@ -5,7 +5,6 @@ const { requireUser } = require("../access-helpers");
 const {
   user: getUser,
   documentsWithProjectCode,
-  documents: getDocuments,
   documentsForAgency,
   createDocument
 } = require("../db");


### PR DESCRIPTION
This fixes the issue where the RI dashboard page shows 81,000 sub-recipients, and when you click on the Subrecipients entry in the Spreadsheets tab, the browser crashes.