### PR TITLE
Candidate fix for issue #22

### DIFF
--- a/src/server/lib/field-name-mapping.js
+++ b/src/server/lib/field-name-mapping.js
@@ -29,7 +29,7 @@ const sheetNameAliases = {
   subrecipients: "subrecipient"
 };
 
-/*  columnNameMap keys are column names in the Treasury Output Workbook,
+/* columnNameMap keys are column names in the Treasury Output Workbook,
   values are the column names in the Agency Input Workbooks, forced
   to lower case by getTemplateSheets()
 */
@@ -77,7 +77,7 @@ const columnNameMap = {
   "Obligation Date": "obligation date",
   "Obligation Project": "project id",
   "Organization Type": "organization type",
-  "Payment Amount": "payment amount",
+  // "Payment Amount": "total payment amount",
   "Payment Date": "payment date",
   "Payment Project": "project id",
   "Period of Performance End Date": "period of performance end date",
@@ -300,7 +300,6 @@ const expenditureColumnNames = {
     project: "Expenditure Project",
     start: "Expenditure Start Date",
     end: "Expenditure End Date"
-
   },
   Loans: {
     amount: "Payment Amount",


### PR DESCRIPTION
Regarding the issue we've been discussing on the Loans tab: we've reviewed the guidance and have determined the best way to handle is to ask you to remove the logic that populates the payment amount if someone populates the expenditure category from the Loans tab.
 
Let me know if that makes sense and is doable.
 
Thank you
Steve

----

How about this as a solution?

1. In the Loans tab only, if the Total Payment Amount (column R) is missing, ignore the detail columns (columns T-AM).
2. If the Total Payment Amount (column R) is present, then the sum of columns T-AL must equal the amount in column R.

Restriction 2 is needed because in the Treasury output spreadsheet, each expense category must go on its own row, in which case we need break down the amount in column R, and the only way we have to do that is the detail columns.

Michael,

----

This solution works I think.  I’ve attached the original workbook 075 that brought this up.  In column R there are no values, so in this case, your proposed fix would ignore the values in (T-AM) and the Payment Amount column will not be populated with data in the Treasury Output file – which is what we want.   This should prevent data in that column from ultimately being populated in the Output file if this specific condition exists.
 
Steve