### PR TITLE
add back projectById needed for UI to edit projects

### DIFF
--- a/src/server/db/index.js
+++ b/src/server/db/index.js
@@ -41,6 +41,7 @@ const {
   getProject,
   getProjects,
   projectByCode,
+  projectById,
   projects,
   updateProject,
   updateProjectStatus
@@ -221,6 +222,7 @@ module.exports = {
   knex,
   markAccessTokenUsed,
   projectByCode,
+  projectById,
   projects,
   reportingPeriods,
   roles,

--- a/src/server/db/projects.js
+++ b/src/server/db/projects.js
@@ -61,6 +61,13 @@ function projectByCode(code) {
     .where({ code });
 }
 
+function projectById(id) {
+  return knex("projects")
+    .select("*")
+    .where({ id })
+    .then(r => r[0]);
+}
+
 /* updateProjectStatus() updates a project status from an uploaded agency
   spreadsheet
   */
@@ -123,6 +130,7 @@ module.exports = {
   getProject,
   getProjects,
   projectByCode,
+  projectById,
   projects,
   updateProject,
   updateProjectStatus

--- a/src/server/routes/projects.js
+++ b/src/server/routes/projects.js
@@ -5,7 +5,7 @@ const router = express.Router();
 const {
   agencyById,
   projects,
-  getProject,
+  projectById,
   createProject,
   updateProject
 } = require("../db");
@@ -64,7 +64,7 @@ router.put("/:id", requireAdminUser, validateProject, async function(
   next
 ) {
   console.log("PUT /projects/:id", req.body);
-  let project = await getProject(req.params.id);
+  let project = await projectById(req.params.id);
   if (!project) {
     res.status(400).send("Project not found");
     return;


### PR DESCRIPTION
The function getProject was written to fetch using primary key. That was changed to lookup by project code, which breaks the UI for editing projects. A new function called projectById has been added with the previous functionality, and the API for the UI now uses the new function