### PR TITLE
Time test

### DIFF
--- a/src/views/ReportingPeriods.vue
+++ b/src/views/ReportingPeriods.vue
@@ -127,7 +127,7 @@ export default {
       }
     },
     formatDate (d) {
-      return moment(d).utc().format('MM/DD/YYYY HH:mm') // test
+      return moment(d).utc().format('MM/DD/YYYY')
     }
   }
 }


### PR DESCRIPTION
The database had the time in UTC. Render transmitted it to the client as UTC, so the client set it back 5 or 6 hours to local time, so it displayed as the day before. Since the period open and close dates only care about the date, not the time, the fix was to display the UTC date rather than the local date.